### PR TITLE
fix: some lootingbots config changes

### DIFF
--- a/BepInEx/config/me.skwizzy.lootingbots.cfg
+++ b/BepInEx/config/me.skwizzy.lootingbots.cfg
@@ -13,7 +13,7 @@ Enable corpse looting = Scav, Pmc, PlayerScav, Raider
 ## When scanning for loot, corpses will be ignored if they are not visible by the bot
 # Setting type: Boolean
 # Default value: false
-Enable corpse line of sight check = false
+Enable corpse line of sight check = true
 
 ## Distance (in meters) a bot is able to detect a corpse
 # Setting type: Single
@@ -47,12 +47,12 @@ Enable loose item looting = Scav, Pmc, PlayerScav, Raider
 ## When scanning for loot, loose items will be ignored if they are not visible by the bot
 # Setting type: Boolean
 # Default value: false
-Enable item line of sight check = false
+Enable item line of sight check = true
 
 ## Distance (in meters) a bot is able to detect an item
 # Setting type: Single
 # Default value: 75
-Detect item distance = 75
+Detect item distance = 125
 
 ## Enable different levels of log messages to show in the logs
 # Setting type: LogLevel


### PR DESCRIPTION
- pass `Enable corpse line of sight check` to true.
- pass `Enable item line of sight check` to true.
- detect item distance => from 75 to 125.