### PR TITLE
Update Raid Overhaul bosslegion.json

### DIFF
--- a/user/mods/RaidOverhaul/db/RaidBoss/bosslegion.json
+++ b/user/mods/RaidOverhaul/db/RaidBoss/bosslegion.json
@@ -2318,8 +2318,8 @@
             "min": 0
         },
         "reward": {
-            "max": 2450,
-            "min": 2450
+            "max": 800,
+            "min": 800
         },
         "standingForKill": -0.2
     },


### PR DESCRIPTION
Nerf XP reward, from 2450 to 800